### PR TITLE
Fix deprecated expectErrorMessage call

### DIFF
--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -1941,7 +1941,7 @@ class oublog_locallib_test extends oublog_test_lib {
         $this->setUser($user);
         list($oublog, $oubloginstance) = oublog_get_personal_blog($USER->id);
         $cm = get_coursemodule_from_instance('oublog', $oublog->id);
-        $this->expectErrorMessage('Sorry: you do not have access to view this page.');
+        $this->expectExceptionMessage('Sorry: you do not have access to view this page.');
         oublog_check_view_permissions($oublog, context_module::instance($cm->id), $cm);
 }
 


### PR DESCRIPTION
Upstream PR: https://github.com/moodleou/moodle-mod_oublog/pull/152
Upstream issue: https://github.com/moodleou/moodle-mod_oublog/issues/151

The `CATALYST_404_STABLE` branch was created from `MOODLE_404_STABLE`.